### PR TITLE
feat: fix playlist limit, add folder sync option, and refactor client

### DIFF
--- a/backend/api/routers/playlists.py
+++ b/backend/api/routers/playlists.py
@@ -18,6 +18,7 @@ class MonitorPlaylistRequest(BaseModel):
     quality: Literal["LOW", "HIGH", "LOSSLESS", "HI_RES"] = "LOSSLESS"
     source: Literal["tidal", "listenbrainz"] = "tidal"
     extra_config: Optional[Dict[str, Any]] = None
+    use_playlist_folder: bool = False
 
 class DeleteFilesRequest(BaseModel):
     files: List[str]
@@ -57,7 +58,8 @@ async def monitor_playlist(
             request.frequency, 
             request.quality,
             request.source,
-            request.extra_config
+            request.extra_config,
+            request.use_playlist_folder
         )
         
         # Start initial sync in background only if new

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     use_musicbrainz: bool = True
     run_beets: bool = False
     embed_lyrics: bool = False
+    group_compilations: bool = True
     
     # Jellyfin Integration
     jellyfin_url: Optional[str] = None

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -386,8 +386,8 @@ class ApiClient {
         return this.get("/playlists/monitored");
     }
 
-    monitorPlaylist(uuid, name, frequency, quality, source = "tidal", extra_config = null) {
-        return this.post("/playlists/monitor", { uuid, name, frequency, quality, source, extra_config });
+    monitorPlaylist(uuid, name, frequency, quality, source = "tidal", extra_config = null, use_playlist_folder = false) {
+        return this.post("/playlists/monitor", { uuid, name, frequency, quality, source, extra_config, use_playlist_folder });
     }
 
     removeMonitoredPlaylist(uuid) {

--- a/frontend/src/components/TidalPlaylists/MonitoredList.jsx
+++ b/frontend/src/components/TidalPlaylists/MonitoredList.jsx
@@ -111,7 +111,10 @@ export function MonitoredList() {
                                                 playlist.uuid,
                                                 playlist.name,
                                                 newFreq,
-                                                playlist.quality
+                                                playlist.quality,
+                                                playlist.source,
+                                                playlist.extra_config,
+                                                playlist.use_playlist_folder
                                             ).then(() => {
                                                 addToast("Frequency updated", "success");
                                                 fetchPlaylists(); // Refresh to be sure

--- a/frontend/src/components/TidalPlaylists/PlaylistSearch.jsx
+++ b/frontend/src/components/TidalPlaylists/PlaylistSearch.jsx
@@ -8,15 +8,15 @@ function extractPlaylistUuid(input) {
     if (!input) return null;
     const trimmed = input.trim();
 
-    
+
     const uuidPattern = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
-    
+
     if (uuidPattern.test(trimmed)) {
         return trimmed;
     }
 
-    
+
     const urlMatch = trimmed.match(/tidal\.com\/(?:browse\/)?playlist\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i);
     if (urlMatch) {
         return urlMatch[1];
@@ -30,16 +30,16 @@ export function PlaylistSearch({ onSyncStarted }) {
     const [loading, setLoading] = useState(false);
     const [results, setResults] = useState([]);
     const [officialOnly, setOfficialOnly] = useState(false);
-    const [selectedPlaylist, setSelectedPlaylist] = useState(null); 
+    const [selectedPlaylist, setSelectedPlaylist] = useState(null);
     const addToast = useToastStore((state) => state.addToast);
 
     const handleSearch = async () => {
         if (!query.trim()) return;
 
-        
+
         const extractedUuid = extractPlaylistUuid(query);
         if (extractedUuid) {
-            
+
             setLoading(true);
             setResults([]);
             try {
@@ -85,7 +85,7 @@ export function PlaylistSearch({ onSyncStarted }) {
     const [monitoredUuids, setMonitoredUuids] = useState(new Set());
 
     useEffect(() => {
-        
+
         api.getMonitoredPlaylists().then(list => {
             setMonitoredUuids(new Set(list.map(p => p.uuid)));
         }).catch(err => console.error("Failed to load monitored status", err));
@@ -330,6 +330,7 @@ function PlaylistCoverImage({ cover, title }) {
 function MonitorModal({ playlist, onClose, onSuccess }) {
     const [frequency, setFrequency] = useState("manual");
     const [quality, setQuality] = useState("LOSSLESS");
+    const [usePlaylistFolder, setUsePlaylistFolder] = useState(false);
     const [submitting, setSubmitting] = useState(false);
     const addToast = useToastStore((state) => state.addToast);
 
@@ -338,7 +339,8 @@ function MonitorModal({ playlist, onClose, onSuccess }) {
         setSubmitting(true);
         try {
             const uuid = playlist.uuid || playlist.id;
-            await api.monitorPlaylist(uuid, playlist.title, frequency, quality);
+            // monitorPlaylist(uuid, name, frequency, quality, source, extra_config, use_playlist_folder)
+            await api.monitorPlaylist(uuid, playlist.title, frequency, quality, "tidal", null, usePlaylistFolder);
             addToast(`Started monitoring "${playlist.title}"`, "success");
             onSuccess();
         } catch (e) {
@@ -389,6 +391,22 @@ function MonitorModal({ playlist, onClose, onSuccess }) {
                             <option value="LOSSLESS">Lossless (FLAC 16bit)</option>
                             <option value="HI_RES">Hi-Res (FLAC 24bit)</option>
                         </select>
+                    </div>
+
+                    <div>
+                        <label class="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={usePlaylistFolder}
+                                onChange={(e) => setUsePlaylistFolder(e.target.checked)}
+                                class="rounded border-border text-primary focus:ring-primary h-4 w-4"
+                            />
+                            <span class="text-sm font-medium text-text">Download tracks to playlist folder</span>
+                        </label>
+                        <p class="text-xs text-text-muted mt-1 ml-6">
+                            Creates a standalone folder "{playlist.title}" containing all tracks.
+                            Useful for keeping files together, but duplicates tracks if they already exist in library.
+                        </p>
                     </div>
 
                     <div class="flex gap-3 justify-end mt-6">


### PR DESCRIPTION
# Playlist Improvements: Pagination, Folder Organization & Stability Fixes

## Description
This PR addresses stability issue regarding playlist handling, and introduces a new configuration option for file organization.

The primary goal was to resolve the 100-track limit on playlist downloads by properly paginating API requests. Additionally, a new feature allows users to force downloads into a dedicated playlist folder, bypassing the standard Artist/Album structure.

## Changes

### 1. Feature: Standalone Playlist Folders
- Added a "Download tracks to playlist folder" option in the Monitor/Sync modal.
- **Behavior**: When enabled, tracks are downloaded directly into `tidaloader_playlists/{PlaylistName}/`.
- **Scope**: Applies to all Monitored Playlists (Tidal & ListenBrainz).
- **Context**: This allows users to keep playlist files self-contained. Note that this may result in file duplication if the tracks already exist in the main library, which is the intended behavior for this specific mode.

### 2. Fix: 100-Track Limit
- ADDRESSED: Issue where only the first 100 tracks of a playlist were retrieved.
- IMPLEMENTATION: Added pagination logic in `get_playlist_tracks` to iteratively fetch all available tracks (with a safety cap at 10,000).

### 3. Fix: Settings Attribute Error
- ADDRESSED: `AttributeError: group_compilations` causing manual sync tasks to fail.
- IMPLEMENTATION: Added the missing default `group_compilations` attribute to the Settings model in `backend/api/settings.py`.

### 4. Code Refactor
- Refactored `backend/tidal_client.py` to simplify the `get_playlist_tracks` method.
- Reduced cyclomatic complexity and improved readability of the pagination loop and response extraction logic.

## How to Test

1. **Sync Fix**: Trigger a manual sync on an existing playlist to verify the process no longer crashes.
2. **Pagination**: Add a playlist containing more than 100 tracks and verify that the total track count is correct in the UI and that all files are queued/downloaded.
3. **Folder Feature**:
   - Add a new playlist to monitor (Tidal or ListenBrainz).
   - Check the "Download tracks to playlist folder" option.
   - Verify that files are downloaded into `downloads/tidaloader_playlists/{PlaylistName}/` as a flat list, alongside the `.m3u8` and cover image.

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Refactoring