### PR TITLE
Fix/general improvements

### DIFF
--- a/backend/api/routers/playlists.py
+++ b/backend/api/routers/playlists.py
@@ -61,6 +61,7 @@ async def monitor_playlist(
             request.quality,
             request.source,
             request.extra_config,
+            use_playlist_folder=request.use_playlist_folder
         )
         
         logger.info(f"MONITOR REQUEST: UUID={request.uuid}, Name={request.name}, Skip={request.skip_download}, ProgressID={request.initial_sync_progress_id}")

--- a/backend/api/routers/spotify.py
+++ b/backend/api/routers/spotify.py
@@ -25,6 +25,18 @@ async def search_spotify_playlists(
     """Search for Spotify playlists"""
     client = SpotifyClient()
     try:
+        # Check if query is a direct URL/URI
+        if "spotify.com" in query or "spotify:playlist:" in query:
+            # It's likely a URL/URI
+            playlist_id = extract_spotify_id(query)
+            if playlist_id and len(playlist_id) > 5: # Basic sanity check
+                specific_playlist = await client.get_playlist_metadata(playlist_id)
+                if specific_playlist:
+                    return {"items": [specific_playlist]}
+                # If specific fetch fails or returns None, fallback to empty or search? 
+                # Let's return empty to avoid searching for the URL string which gives garbage.
+                return {"items": []}
+
         playlists = await client.search_playlists(query)
         return {"items": playlists}
     except Exception as e:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,4 @@ httpx==0.25.2
 pytest-asyncio==0.23.2
 apscheduler==3.10.4
 Pillow
+beautifulsoup4


### PR DESCRIPTION
# General Improvements & Fixes

## New Features

### Spotify URL Support in "Search & Add"
- **Enhancement**: You can now paste a direct Spotify playlist URL (e.g., `https://open.spotify.com/playlist/...`) into the "Search & Add" bar.
- **Hybrid Metadata Fetching**: Implemented a robust metadata retrieval system.
    - Uses **HTML Scraping** (via `BeautifulSoup`) to instantly fetch the exact Title, Cover Image, and Owner from the public Spotify page (bypassing the unreliable fuzzy search API).
    - Uses the internal API to retrieve the accurate track count.
- **Result**: Ensures the preview card in the UI exactly matches the pasted link, solving the issue where searching by ID sometimes returned unrelated playlists.

## Bug Fixes
- **Separate Folder Strategy**: Fixed an issue where the "Download to separate folder" option was ignored during imports.

## Maintenance
- **Dependencies**: Added `beautifulsoup4` for robust metadata scraping.